### PR TITLE
fix: rename app title to Budget Wise; use static SVG logo path

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "budget-wise-backend"
-version = "1.0.0"
+version = "1.1.0"
 description = "FastAPI backend for BudgetWise"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "packageManager": "pnpm@10.15.0",
   "scripts": {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -4,7 +4,7 @@ import Header from '@/components/header'
 import Footer from '@/components/footer'
 
 export const metadata = {
-  title: 'Budget App',
+  title: 'Budget Wise',
   description: 'Upload your bank statements and categorize transactions',
 }
 

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link'
 import Image from 'next/image'
-import BudgetWiseIcon from '~/public/budget-wise-logo.min.svg'
 
 export default function Header() {
   return (
@@ -8,7 +7,7 @@ export default function Header() {
       <div className="mx-auto flex h-14 max-w-5xl items-center gap-3 px-4 sm:px-6">
         <Link href="/" className="flex items-center gap-2">
           <Image
-            src={BudgetWiseIcon}
+            src="/budget-wise-logo.min.svg"
             alt="Budget Wise logo"
             width={28}
             height={28}


### PR DESCRIPTION
- Updated Next.js `metadata.title` in `app/layout.tsx` from **Budget App** to **Budget Wise**.
- Switched header logo to load from `/public`:
  - Removed `BudgetWiseIcon` SVG import in `components/header.tsx`.
  - Set `<Image src="/budget-wise-logo.min.svg" ...>` (kept alt text and dimensions).
- Rationale: serve the logo as a static asset for simpler bundling and predictable caching in App Router.